### PR TITLE
webpack does not like relative paths

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,7 @@ var CopyWebpackPlugin = require('copy-webpack-plugin');
 module.exports = {
     entry: "./rsk-conversion-utils.js",
     output: {
-        path: './build/lib',
+        path: __dirname + '/build/lib',
 		filename: 'rsk-conversion-utils.js',
 		libraryTarget: 'var',
 		library: 'RSKUtils'


### PR DESCRIPTION
I Believe this is the correct way to specify correct paths. This resolves my issue:
webpack --verbose
Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
 - configuration.output.path: The provided value "./build/lib" is not an absolute path!